### PR TITLE
fix(CI): Conditionally set Cloudflare credentials in test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,8 +39,8 @@ jobs:
         env:
           UNRAVEL_API_KEY: ${{ inputs.base_url && secrets.UNRAVEL_API_KEY_STAGING || secrets.UNRAVEL_API_KEY }}
           UNRAVEL_BASE_URL: ${{ inputs.base_url || 'https://unravel.finance' }}
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ inputs.base_url && secrets.CF_ACCESS_CLIENT_ID || '' }}
+          CF_ACCESS_CLIENT_SECRET: ${{ inputs.base_url && secrets.CF_ACCESS_CLIENT_SECRET || '' }}
         run: pytest . -s --cov --durations 0
 
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary
Updated the GitHub Actions test workflow to conditionally set Cloudflare Access credentials based on whether a custom base URL is provided as input.

## Key Changes
- Modified `CF_ACCESS_CLIENT_ID` environment variable to only use the secret when `inputs.base_url` is provided, otherwise defaults to empty string
- Modified `CF_ACCESS_CLIENT_SECRET` environment variable to only use the secret when `inputs.base_url` is provided, otherwise defaults to empty string

## Implementation Details
The changes follow the same conditional pattern already used for `UNRAVEL_API_KEY`, ensuring that Cloudflare credentials are only injected into the test environment when running against a staging/custom base URL. This prevents unnecessary credential exposure and aligns the credential handling logic across all environment variables in the workflow.

https://claude.ai/code/session_01F3AfH5mvqwb8qCyXS2Kmq8