### PR TITLE
feat(Live): Add as_of parameter to live-weights and live-factors endpoints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - macos-latest
         python-version:
           - "3.9"

--- a/src/unravel_client/portfolio/factors.py
+++ b/src/unravel_client/portfolio/factors.py
@@ -57,6 +57,7 @@ def get_portfolio_factors_live(
     tickers: list[str],
     api_key: str,
     smoothing: str | None = None,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Fetch the latest factor data for specific tickers within a single factor portfolio.
@@ -66,6 +67,7 @@ def get_portfolio_factors_live(
         tickers (list[str]): List of tickers in the portfolio
         api_key (str): The API key to use for the request
         smoothing (str | None): Portfolio smoothing window for the data. Valid values are 0 (no smoothing), 5, 10, 15, 20, or 30 days.
+        as_of (str | None): Point in time for the data. Valid options are 'close' or 'latest'.
     Returns:
         pd.Series: Latest factor data for the specified tickers
     """
@@ -74,6 +76,8 @@ def get_portfolio_factors_live(
 
     if smoothing is not None:
         params["smoothing"] = smoothing
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/src/unravel_client/portfolio/live_weights.py
+++ b/src/unravel_client/portfolio/live_weights.py
@@ -13,6 +13,7 @@ def get_live_weights(
     api_key: str,
     smoothing: str | None = None,
     exchange: str | None = None,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Fetch last value of normalized risk signal data from the Unravel API.
@@ -22,6 +23,7 @@ def get_live_weights(
         api_key (str): The API key to use for the request
         smoothing (str | None): Portfolio smoothing window for the data. Portfolio smoothing window for the data. Valid values and default smoothing for each portfolio can be found in the [Unravel Catalog](https://unravel.finance/home/api/catalog)
         exchange (str | None): Exchange constraint for portfolio data. Valid options are found in the [Unravel Catalog](https://unravel.finance/home/api/catalog)
+        as_of (str | None): Point in time for the data. Valid options are 'close' or 'latest'.
     Returns:
         pd.Series: Current weights of the portfolio
     """
@@ -32,6 +34,8 @@ def get_live_weights(
         params["smoothing"] = smoothing
     if exchange is not None:
         params["exchange"] = exchange
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/tests/test_live_weights.py
+++ b/tests/test_live_weights.py
@@ -22,3 +22,13 @@ def test_series_dtypes(api_key, test_portfolio):
 
     # Check that all values are float type
     assert pd.api.types.is_float_dtype(result)
+
+
+def test_as_of_close_vs_latest_differ(api_key, test_portfolio):
+    """Test that as_of='close' and as_of='latest' return different results."""
+    result_close = get_live_weights(id=test_portfolio, api_key=api_key, as_of="close")
+    result_latest = get_live_weights(id=test_portfolio, api_key=api_key, as_of="latest")
+
+    assert not result_close.equals(result_latest), (
+        "as_of='close' and as_of='latest' should return different weights"
+    )

--- a/tests/test_portfolio_factors_live.py
+++ b/tests/test_portfolio_factors_live.py
@@ -53,3 +53,30 @@ def test_get_portfolio_factors_live_with_smoothing(
         assert isinstance(result, pd.Series)
         assert len(result) > 0, "Should have some live factor data"
         assert pd.api.types.is_float_dtype(result), "Values should be float type"
+
+
+def test_as_of_close_vs_latest_differ(api_key, test_portfolio, test_portfolio_base):
+    """Test that as_of='close' and as_of='latest' return different results."""
+    tickers = get_tickers(
+        id=test_portfolio_base,
+        api_key=api_key,
+        universe_size=20,
+    )
+
+    if len(tickers) > 0:
+        result_close = get_portfolio_factors_live(
+            id=test_portfolio,
+            tickers=tickers[:3],
+            api_key=api_key,
+            as_of="close",
+        )
+        result_latest = get_portfolio_factors_live(
+            id=test_portfolio,
+            tickers=tickers[:3],
+            api_key=api_key,
+            as_of="latest",
+        )
+
+        assert not result_close.equals(result_latest), (
+            "as_of='close' and as_of='latest' should return different factor values"
+        )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Added `as_of: str | None = None` parameter to `get_live_weights()` in `portfolio/live_weights.py`
- Added `as_of: str | None = None` parameter to `get_portfolio_factors_live()` in `portfolio/factors.py`
- When `None` (default), the parameter is not included in the API request
- Valid values are `'close'` and `'latest'`

## Test plan

- [ ] Call `get_live_weights(..., as_of='close')` and verify `as_of=close` is included in the request params
- [ ] Call `get_live_weights(..., as_of='latest')` and verify `as_of=latest` is included in the request params
- [ ] Call `get_live_weights(...)` without `as_of` and verify no `as_of` param is sent
- [ ] Same three checks for `get_portfolio_factors_live()`

https://claude.ai/code/session_0171294xKYWEJYbggV7sErU3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171294xKYWEJYbggV7sErU3)_