### PR TITLE
Add as_of parameter to live endpoints and test latest vs close differ

### DIFF
--- a/src/unravel_client/portfolio/factors.py
+++ b/src/unravel_client/portfolio/factors.py
@@ -57,6 +57,7 @@ def get_portfolio_factors_live(
     tickers: list[str],
     api_key: str,
     smoothing: str | None = None,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Fetch the latest factor data for specific tickers within a single factor portfolio.
@@ -66,6 +67,7 @@ def get_portfolio_factors_live(
         tickers (list[str]): List of tickers in the portfolio
         api_key (str): The API key to use for the request
         smoothing (str | None): Portfolio smoothing window for the data. Valid values are 0 (no smoothing), 5, 10, 15, 20, or 30 days.
+        as_of (str | None): Point-in-time reference for the data. Valid values are "latest" (most recent intraday data) and "close" (previous market close).
     Returns:
         pd.Series: Latest factor data for the specified tickers
     """
@@ -74,6 +76,8 @@ def get_portfolio_factors_live(
 
     if smoothing is not None:
         params["smoothing"] = smoothing
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/src/unravel_client/portfolio/live_weights.py
+++ b/src/unravel_client/portfolio/live_weights.py
@@ -13,6 +13,7 @@ def get_live_weights(
     api_key: str,
     smoothing: str | None = None,
     exchange: str | None = None,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Fetch last value of normalized risk signal data from the Unravel API.
@@ -22,6 +23,7 @@ def get_live_weights(
         api_key (str): The API key to use for the request
         smoothing (str | None): Portfolio smoothing window for the data. Portfolio smoothing window for the data. Valid values and default smoothing for each portfolio can be found in the [Unravel Catalog](https://unravel.finance/home/api/catalog)
         exchange (str | None): Exchange constraint for portfolio data. Valid options are found in the [Unravel Catalog](https://unravel.finance/home/api/catalog)
+        as_of (str | None): Point-in-time reference for the data. Valid values are "latest" (most recent intraday data) and "close" (previous market close).
     Returns:
         pd.Series: Current weights of the portfolio
     """
@@ -32,6 +34,8 @@ def get_live_weights(
         params["smoothing"] = smoothing
     if exchange is not None:
         params["exchange"] = exchange
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/src/unravel_client/portfolio/risk.py
+++ b/src/unravel_client/portfolio/risk.py
@@ -56,6 +56,7 @@ def get_risk_overlay_live(
     portfolio: str,
     overlay: str,
     api_key: str,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Retrieve the latest risk overlay value for a portfolio.
@@ -64,6 +65,7 @@ def get_risk_overlay_live(
         portfolio: Portfolio ID (see [Unravel Catalog](https://unravel.finance/home/api/catalog/portfolios))
         overlay: Risk overlay ID (see [Unravel Catalog](https://unravel.finance/home/api/catalog/risk-overlays))
         api_key: API authentication key
+        as_of: Point-in-time reference for the data. Valid values are "latest" (most recent intraday data) and "close" (previous market close).
 
     Returns:
         pd.Series: Series with datetime index and float values representing
@@ -74,6 +76,9 @@ def get_risk_overlay_live(
     """
     url = f"{BASEAPI}/portfolio/risk-overlay-live"
     params = {"portfolio": portfolio, "overlay": overlay}
+
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)
@@ -131,6 +136,7 @@ def get_risk_regime(
 def get_risk_regime_live(
     overlay: str,
     api_key: str,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Retrieve the latest market-wide risk regime value.
@@ -138,6 +144,7 @@ def get_risk_regime_live(
     Args:
         overlay: Risk overlay ID (see [Unravel Catalog](https://unravel.finance/home/api/catalog/risk-overlays))
         api_key: API authentication key
+        as_of: Point-in-time reference for the data. Valid values are "latest" (most recent intraday data) and "close" (previous market close).
 
     Returns:
         pd.Series: Series with datetime index and float values representing
@@ -148,6 +155,9 @@ def get_risk_regime_live(
     """
     url = f"{BASEAPI}/risk-regime-live"
     params = {"overlay": overlay}
+
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/tests/test_live_as_of.py
+++ b/tests/test_live_as_of.py
@@ -1,0 +1,97 @@
+"""
+Tests that live* endpoints return different values for as_of="latest" vs as_of="close".
+"""
+import pandas as pd
+import pytest
+
+from unravel_client import (
+    get_live_weights,
+    get_portfolio_factors_live,
+    get_risk_overlay_live,
+    get_risk_regime_live,
+    get_tickers,
+)
+
+
+def test_live_weights_latest_vs_close_differ(api_key, test_portfolio):
+    """Passing as_of='latest' and as_of='close' should return different weight values."""
+    result_latest = get_live_weights(id=test_portfolio, api_key=api_key, as_of="latest")
+    result_close = get_live_weights(id=test_portfolio, api_key=api_key, as_of="close")
+
+    assert isinstance(result_latest, pd.Series)
+    assert isinstance(result_close, pd.Series)
+    assert len(result_latest) > 0
+    assert len(result_close) > 0
+
+    # The two snapshots should not be identical
+    assert not result_latest.equals(result_close), (
+        "as_of='latest' and as_of='close' returned identical weights — "
+        "expected them to differ because intraday prices differ from the previous close"
+    )
+
+
+def test_portfolio_factors_live_latest_vs_close_differ(
+    api_key, test_portfolio, test_portfolio_base
+):
+    """Passing as_of='latest' and as_of='close' should return different factor values."""
+    tickers = get_tickers(id=test_portfolio_base, api_key=api_key, universe_size=20)
+    if len(tickers) == 0:
+        pytest.skip("No tickers available for this portfolio")
+
+    sample = tickers[:3]
+    result_latest = get_portfolio_factors_live(
+        id=test_portfolio, tickers=sample, api_key=api_key, as_of="latest"
+    )
+    result_close = get_portfolio_factors_live(
+        id=test_portfolio, tickers=sample, api_key=api_key, as_of="close"
+    )
+
+    assert isinstance(result_latest, pd.Series)
+    assert isinstance(result_close, pd.Series)
+    assert len(result_latest) > 0
+    assert len(result_close) > 0
+
+    assert not result_latest.equals(result_close), (
+        "as_of='latest' and as_of='close' returned identical factor values — "
+        "expected them to differ because intraday prices differ from the previous close"
+    )
+
+
+def test_risk_overlay_live_latest_vs_close_differ(api_key, test_portfolio_base):
+    """Passing as_of='latest' and as_of='close' should return different overlay values."""
+    result_latest = get_risk_overlay_live(
+        portfolio=test_portfolio_base, overlay="trend", api_key=api_key, as_of="latest"
+    )
+    result_close = get_risk_overlay_live(
+        portfolio=test_portfolio_base, overlay="trend", api_key=api_key, as_of="close"
+    )
+
+    assert isinstance(result_latest, pd.Series)
+    assert isinstance(result_close, pd.Series)
+    assert len(result_latest) == 1
+    assert len(result_close) == 1
+
+    assert not result_latest.equals(result_close), (
+        "as_of='latest' and as_of='close' returned identical risk overlay values — "
+        "expected them to differ because intraday prices differ from the previous close"
+    )
+
+
+def test_risk_regime_live_latest_vs_close_differ(api_key):
+    """Passing as_of='latest' and as_of='close' should return different regime values."""
+    result_latest = get_risk_regime_live(
+        overlay="crypto_trend_consensus", api_key=api_key, as_of="latest"
+    )
+    result_close = get_risk_regime_live(
+        overlay="crypto_trend_consensus", api_key=api_key, as_of="close"
+    )
+
+    assert isinstance(result_latest, pd.Series)
+    assert isinstance(result_close, pd.Series)
+    assert len(result_latest) == 1
+    assert len(result_close) == 1
+
+    assert not result_latest.equals(result_close), (
+        "as_of='latest' and as_of='close' returned identical risk regime values — "
+        "expected them to differ because intraday prices differ from the previous close"
+    )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `as_of` parameter (valid values: `"latest"`, `"close"`) to all four live endpoint functions: `get_live_weights`, `get_portfolio_factors_live`, `get_risk_overlay_live`, and `get_risk_regime_live`
- Introduces `tests/test_live_as_of.py` with one test per live endpoint asserting that `as_of="latest"` and `as_of="close"` return different values

## Test plan

- [ ] Run `pytest tests/test_live_as_of.py` against the alpha environment with `UNRAVEL_API_KEY` set — all four tests should pass, confirming intraday and close snapshots differ
- [ ] Confirm existing tests are unaffected (`pytest tests/` — no regressions)

https://claude.ai/code/session_01BXHdAKhnEQ4oojCNTX6c6x
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXHdAKhnEQ4oojCNTX6c6x)_