### PR TITLE
feature(Live): Add `as_of` param to live endpoints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,13 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       base_url:
-        description: 'API base URL (leave empty for production)'
+        description: 'API base URL. Leave empty for production (https://unravel.finance, uses production credentials). Any other value (staging, preview deployments) runs with staging API key & Cloudflare credentials.'
         required: false
-      use_staging:
-        description: 'Use staging API key & Cloudflare credentials'
-        type: boolean
-        required: false
-        default: false
+
+env:
+  PRODUCTION_URL: 'https://unravel.finance'
 
 jobs:
   run-tests:
@@ -47,10 +45,10 @@ jobs:
 
       - name: run-tests
         env:
-          UNRAVEL_API_KEY: ${{ (inputs.use_staging || inputs.base_url) && secrets.UNRAVEL_API_KEY_STAGING || secrets.UNRAVEL_API_KEY }}
-          UNRAVEL_BASE_URL: ${{ inputs.base_url || 'https://unravel.finance' }}
-          CF_ACCESS_CLIENT_ID: ${{ (inputs.use_staging || inputs.base_url) && secrets.CF_ACCESS_CLIENT_ID || '' }}
-          CF_ACCESS_CLIENT_SECRET: ${{ (inputs.use_staging || inputs.base_url) && secrets.CF_ACCESS_CLIENT_SECRET || '' }}
+          UNRAVEL_BASE_URL: ${{ inputs.base_url || env.PRODUCTION_URL }}
+          UNRAVEL_API_KEY: ${{ inputs.base_url && inputs.base_url != env.PRODUCTION_URL && secrets.UNRAVEL_API_KEY_STAGING || secrets.UNRAVEL_API_KEY }}
+          CF_ACCESS_CLIENT_ID: ${{ inputs.base_url && inputs.base_url != env.PRODUCTION_URL && secrets.CF_ACCESS_CLIENT_ID || '' }}
+          CF_ACCESS_CLIENT_SECRET: ${{ inputs.base_url && inputs.base_url != env.PRODUCTION_URL && secrets.CF_ACCESS_CLIENT_SECRET || '' }}
         run: pytest . -s --cov --durations 0
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,11 @@ on:
       base_url:
         description: 'API base URL (leave empty for production)'
         required: false
+      use_staging:
+        description: 'Use staging API key & Cloudflare credentials'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   run-tests:
@@ -42,10 +47,10 @@ jobs:
 
       - name: run-tests
         env:
-          UNRAVEL_API_KEY: ${{ inputs.base_url && secrets.UNRAVEL_API_KEY_STAGING || secrets.UNRAVEL_API_KEY }}
+          UNRAVEL_API_KEY: ${{ (inputs.use_staging || inputs.base_url) && secrets.UNRAVEL_API_KEY_STAGING || secrets.UNRAVEL_API_KEY }}
           UNRAVEL_BASE_URL: ${{ inputs.base_url || 'https://unravel.finance' }}
-          CF_ACCESS_CLIENT_ID: ${{ inputs.base_url && secrets.CF_ACCESS_CLIENT_ID || '' }}
-          CF_ACCESS_CLIENT_SECRET: ${{ inputs.base_url && secrets.CF_ACCESS_CLIENT_SECRET || '' }}
+          CF_ACCESS_CLIENT_ID: ${{ (inputs.use_staging || inputs.base_url) && secrets.CF_ACCESS_CLIENT_ID || '' }}
+          CF_ACCESS_CLIENT_SECRET: ${{ (inputs.use_staging || inputs.base_url) && secrets.CF_ACCESS_CLIENT_SECRET || '' }}
         run: pytest . -s --cov --durations 0
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - macos-latest
         python-version:
           - "3.9"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,14 +22,266 @@
       "justMyCode": true
     },
     {
-      "name": "Endpoint: sample call",
+      "name": "Endpoint: get_historical_universe",
       "type": "debugpy",
       "request": "launch",
       "python": "${config:python.defaultInterpreterPath}",
       "program": "${workspaceFolder}/scripts/run_endpoint.py",
       "args": [
         "--endpoint",
-        "${input:unravelEndpoint}",
+        "get_historical_universe",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_live_weights",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_live_weights",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_portfolio_factors_historical",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_portfolio_factors_historical",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_portfolio_factors_live",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_portfolio_factors_live",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_portfolio_historical_weights",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_portfolio_historical_weights",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_portfolio_returns",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_portfolio_returns",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_price",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_price",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_prices",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_prices",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_risk_overlay",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_risk_overlay",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_risk_overlay_live",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_risk_overlay_live",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_risk_regime",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_risk_regime",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_risk_regime_live",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_risk_regime_live",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: get_tickers",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "get_tickers",
         "--overrides",
         "${input:endpointOverrides}"
       ],
@@ -44,33 +296,6 @@
     }
   ],
   "inputs": [
-    {
-      "id": "pytestTarget",
-      "type": "promptString",
-      "description": "Pytest target relative to the tests folder, or use an absolute path",
-      "default": "."
-    },
-    {
-      "id": "unravelEndpoint",
-      "type": "pickString",
-      "description": "Choose the endpoint to call",
-      "options": [
-        "get_historical_universe",
-        "get_live_weights",
-        "get_portfolio_factors_historical",
-        "get_portfolio_factors_live",
-        "get_portfolio_historical_weights",
-        "get_portfolio_returns",
-        "get_price",
-        "get_prices",
-        "get_risk_overlay",
-        "get_risk_overlay_live",
-        "get_risk_regime",
-        "get_risk_regime_live",
-        "get_tickers"
-      ],
-      "default": "get_live_weights"
-    },
     {
       "id": "endpointOverrides",
       "type": "promptString",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,81 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Pytest: all tests",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "module": "pytest",
+      "args": [
+        ".",
+        "-vv",
+        "-s"
+      ],
+      "cwd": "${workspaceFolder}/tests",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Endpoint: sample call",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${config:python.defaultInterpreterPath}",
+      "program": "${workspaceFolder}/scripts/run_endpoint.py",
+      "args": [
+        "--endpoint",
+        "${input:unravelEndpoint}",
+        "--overrides",
+        "${input:endpointOverrides}"
+      ],
+      "cwd": "${workspaceFolder}/scripts",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONSAFEPATH": "1"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": true
+    }
+  ],
+  "inputs": [
+    {
+      "id": "pytestTarget",
+      "type": "promptString",
+      "description": "Pytest target relative to the tests folder, or use an absolute path",
+      "default": "."
+    },
+    {
+      "id": "unravelEndpoint",
+      "type": "pickString",
+      "description": "Choose the endpoint to call",
+      "options": [
+        "get_historical_universe",
+        "get_live_weights",
+        "get_portfolio_factors_historical",
+        "get_portfolio_factors_live",
+        "get_portfolio_historical_weights",
+        "get_portfolio_returns",
+        "get_price",
+        "get_prices",
+        "get_risk_overlay",
+        "get_risk_overlay_live",
+        "get_risk_regime",
+        "get_risk_regime_live",
+        "get_tickers"
+      ],
+      "default": "get_live_weights"
+    },
+    {
+      "id": "endpointOverrides",
+      "type": "promptString",
+      "description": "Optional JSON overrides for the sample kwargs",
+      "default": ""
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ pytest tests/test_unravel_client.py::TestErrorHandling -v
 
 ### VS Code launch configurations
 
-The repository now includes a compact `.vscode/launch.json` with reusable entries instead of one launch config per endpoint or test file:
+The repository now includes:
 
 - `Pytest: all tests`
-- `Endpoint: sample call` to run any exported client endpoint from a single picker
+- one `Endpoint: ...` launch entry for each exported client endpoint
 
-`Endpoint: sample call` uses sensible defaults based on the existing test suite and reads `UNRAVEL_API_KEY` from `.env`. If you want to tweak a call without editing code, pass JSON overrides when prompted, for example:
+Each endpoint launch uses sensible defaults based on the existing test suite and reads `UNRAVEL_API_KEY` from `.env`. If you want to tweak a call without editing code, pass JSON overrides when prompted, for example:
 
 ```json
 {"as_of":"latest"}

--- a/README.md
+++ b/README.md
@@ -127,6 +127,25 @@ pytest tests/test_unravel_client.py::TestRiskSignalFunctions -v
 pytest tests/test_unravel_client.py::TestErrorHandling -v
 ```
 
+### VS Code launch configurations
+
+The repository now includes a compact `.vscode/launch.json` with reusable entries instead of one launch config per endpoint or test file:
+
+- `Pytest: all tests`
+- `Endpoint: sample call` to run any exported client endpoint from a single picker
+
+`Endpoint: sample call` uses sensible defaults based on the existing test suite and reads `UNRAVEL_API_KEY` from `.env`. If you want to tweak a call without editing code, pass JSON overrides when prompted, for example:
+
+```json
+{"as_of":"latest"}
+```
+
+or
+
+```json
+{"start_date":"2024-01-01","end_date":"2024-01-07"}
+```
+
 ### Test Categories
 
 - **Portfolio Functions**: Tests portfolio-related API calls using `momentum_enhanced.40` portfolio

--- a/scripts/run_endpoint.py
+++ b/scripts/run_endpoint.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import date, timedelta
+from typing import Any, Callable
+
+import pandas as pd
+
+from unravel_client import (
+    get_historical_universe,
+    get_live_weights,
+    get_portfolio_factors_historical,
+    get_portfolio_factors_live,
+    get_portfolio_historical_weights,
+    get_portfolio_returns,
+    get_price,
+    get_prices,
+    get_risk_overlay,
+    get_risk_overlay_live,
+    get_risk_regime,
+    get_risk_regime_live,
+    get_tickers,
+)
+
+DEFAULT_PORTFOLIO = "momentum_enhanced.40"
+DEFAULT_PORTFOLIO_BASE = "momentum_enhanced"
+DEFAULT_OVERLAY = "trend"
+DEFAULT_REGIME_OVERLAY = "crypto_trend_consensus"
+
+EndpointDefaultsFactory = Callable[[str], dict[str, Any]]
+EndpointCallable = Callable[..., Any]
+
+
+def recent_date_range(days: int = 30) -> tuple[str, str]:
+    end_date = date.today()
+    start_date = end_date - timedelta(days=days)
+    return start_date.isoformat(), end_date.isoformat()
+
+
+def sample_factor_tickers(api_key: str, count: int = 3) -> list[str]:
+    tickers = get_tickers(
+        id=DEFAULT_PORTFOLIO_BASE,
+        api_key=api_key,
+        universe_size=20,
+    )
+    if not tickers:
+        msg = "No sample tickers were returned for the default portfolio."
+        raise RuntimeError(msg)
+    return tickers[:count]
+
+
+def defaults_for_get_price(_: str) -> dict[str, Any]:
+    start_date, end_date = recent_date_range()
+    return {
+        "ticker": "BTC",
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def defaults_for_get_prices(_: str) -> dict[str, Any]:
+    start_date, end_date = recent_date_range()
+    return {
+        "tickers": ["BTC", "ETH"],
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def defaults_for_historical_weights(_: str) -> dict[str, Any]:
+    start_date, end_date = recent_date_range()
+    return {
+        "id": DEFAULT_PORTFOLIO,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def defaults_for_live_weights(_: str) -> dict[str, Any]:
+    return {"id": DEFAULT_PORTFOLIO}
+
+
+def defaults_for_returns(_: str) -> dict[str, Any]:
+    start_date, end_date = recent_date_range()
+    return {
+        "id": DEFAULT_PORTFOLIO,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def defaults_for_tickers(_: str) -> dict[str, Any]:
+    return {
+        "id": DEFAULT_PORTFOLIO_BASE,
+        "universe_size": "full",
+    }
+
+
+def defaults_for_factors_historical(api_key: str) -> dict[str, Any]:
+    start_date, end_date = recent_date_range()
+    return {
+        "id": DEFAULT_PORTFOLIO,
+        "tickers": sample_factor_tickers(api_key),
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def defaults_for_factors_live(api_key: str) -> dict[str, Any]:
+    return {
+        "id": DEFAULT_PORTFOLIO,
+        "tickers": sample_factor_tickers(api_key),
+    }
+
+
+def defaults_for_risk_overlay(_: str) -> dict[str, Any]:
+    start_date, end_date = recent_date_range()
+    return {
+        "portfolio": DEFAULT_PORTFOLIO_BASE,
+        "overlay": DEFAULT_OVERLAY,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def defaults_for_risk_overlay_live(_: str) -> dict[str, Any]:
+    return {
+        "portfolio": DEFAULT_PORTFOLIO_BASE,
+        "overlay": DEFAULT_OVERLAY,
+    }
+
+
+def defaults_for_risk_regime(_: str) -> dict[str, Any]:
+    return {
+        "overlay": DEFAULT_REGIME_OVERLAY,
+        "start_date": "2023-01-01",
+        "end_date": "2023-12-31",
+    }
+
+
+def defaults_for_risk_regime_live(_: str) -> dict[str, Any]:
+    return {"overlay": DEFAULT_REGIME_OVERLAY}
+
+
+def defaults_for_historical_universe(_: str) -> dict[str, Any]:
+    return {
+        "size": "20",
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-07",
+    }
+
+
+ENDPOINTS: dict[str, tuple[EndpointCallable, EndpointDefaultsFactory]] = {
+    "get_historical_universe": (get_historical_universe, defaults_for_historical_universe),
+    "get_live_weights": (get_live_weights, defaults_for_live_weights),
+    "get_portfolio_factors_historical": (
+        get_portfolio_factors_historical,
+        defaults_for_factors_historical,
+    ),
+    "get_portfolio_factors_live": (
+        get_portfolio_factors_live,
+        defaults_for_factors_live,
+    ),
+    "get_portfolio_historical_weights": (
+        get_portfolio_historical_weights,
+        defaults_for_historical_weights,
+    ),
+    "get_portfolio_returns": (get_portfolio_returns, defaults_for_returns),
+    "get_price": (get_price, defaults_for_get_price),
+    "get_prices": (get_prices, defaults_for_get_prices),
+    "get_risk_overlay": (get_risk_overlay, defaults_for_risk_overlay),
+    "get_risk_overlay_live": (get_risk_overlay_live, defaults_for_risk_overlay_live),
+    "get_risk_regime": (get_risk_regime, defaults_for_risk_regime),
+    "get_risk_regime_live": (get_risk_regime_live, defaults_for_risk_regime_live),
+    "get_tickers": (get_tickers, defaults_for_tickers),
+}
+
+
+def parse_overrides(raw_overrides: str) -> dict[str, Any]:
+    if not raw_overrides.strip():
+        return {}
+
+    overrides = json.loads(raw_overrides)
+    if not isinstance(overrides, dict):
+        msg = "--overrides must be a JSON object."
+        raise ValueError(msg)
+    return overrides
+
+
+def print_result(result: Any) -> None:
+    print("\nResult summary:")
+
+    if isinstance(result, pd.DataFrame):
+        print(f"type=DataFrame shape={result.shape}")
+        print(result.head().to_string())
+        return
+
+    if isinstance(result, pd.Series):
+        print(f"type=Series length={len(result)}")
+        print(result.head().to_string())
+        return
+
+    if isinstance(result, list):
+        print(f"type=list length={len(result)}")
+        print(json.dumps(result[:10], indent=2))
+        return
+
+    print(repr(result))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a sample call for any exported unravel_client endpoint.",
+    )
+    parser.add_argument(
+        "--endpoint",
+        choices=sorted(ENDPOINTS),
+        required=True,
+        help="Endpoint function to execute.",
+    )
+    parser.add_argument(
+        "--overrides",
+        default="",
+        help='JSON object merged into the default sample kwargs, e.g. {"as_of":"latest"}.',
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    api_key = os.getenv("UNRAVEL_API_KEY")
+    if not api_key:
+        msg = "UNRAVEL_API_KEY is required. Put it in .env or your environment before launching."
+        raise SystemExit(msg)
+
+    endpoint, defaults_factory = ENDPOINTS[args.endpoint]
+    kwargs = defaults_factory(api_key)
+    kwargs.update(parse_overrides(args.overrides))
+
+    print(f"Calling {args.endpoint}")
+    print(json.dumps(kwargs, indent=2, sort_keys=True, default=str))
+
+    result = endpoint(api_key=api_key, **kwargs)
+    print_result(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unravel_client/portfolio/factors.py
+++ b/src/unravel_client/portfolio/factors.py
@@ -57,6 +57,7 @@ def get_portfolio_factors_live(
     tickers: list[str],
     api_key: str,
     smoothing: str | None = None,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Fetch the latest factor data for specific tickers within a single factor portfolio.
@@ -66,6 +67,7 @@ def get_portfolio_factors_live(
         tickers (list[str]): List of tickers in the portfolio
         api_key (str): The API key to use for the request
         smoothing (str | None): Portfolio smoothing window for the data. Valid values are 0 (no smoothing), 5, 10, 15, 20, or 30 days.
+        as_of (str | None): Point in time for the data. Valid options are 'close' or 'latest'.
     Returns:
         pd.Series: Latest factor data for the specified tickers
     """
@@ -74,6 +76,8 @@ def get_portfolio_factors_live(
 
     if smoothing is not None:
         params["smoothing"] = smoothing
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/src/unravel_client/portfolio/live_weights.py
+++ b/src/unravel_client/portfolio/live_weights.py
@@ -13,6 +13,7 @@ def get_live_weights(
     api_key: str,
     smoothing: str | None = None,
     exchange: str | None = None,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Fetch last value of normalized risk signal data from the Unravel API.
@@ -22,6 +23,7 @@ def get_live_weights(
         api_key (str): The API key to use for the request
         smoothing (str | None): Portfolio smoothing window for the data. Portfolio smoothing window for the data. Valid values and default smoothing for each portfolio can be found in the [Unravel Catalog](https://unravel.finance/home/api/catalog)
         exchange (str | None): Exchange constraint for portfolio data. Valid options are found in the [Unravel Catalog](https://unravel.finance/home/api/catalog)
+        as_of (str | None): Point in time for the data. Valid options are 'close' or 'latest'.
     Returns:
         pd.Series: Current weights of the portfolio
     """
@@ -32,6 +34,8 @@ def get_live_weights(
         params["smoothing"] = smoothing
     if exchange is not None:
         params["exchange"] = exchange
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/src/unravel_client/portfolio/risk.py
+++ b/src/unravel_client/portfolio/risk.py
@@ -56,6 +56,7 @@ def get_risk_overlay_live(
     portfolio: str,
     overlay: str,
     api_key: str,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Retrieve the latest risk overlay value for a portfolio.
@@ -64,6 +65,7 @@ def get_risk_overlay_live(
         portfolio: Portfolio ID (see [Unravel Catalog](https://unravel.finance/home/api/catalog/portfolios))
         overlay: Risk overlay ID (see [Unravel Catalog](https://unravel.finance/home/api/catalog/risk-overlays))
         api_key: API authentication key
+        as_of: Optional point in time for the data. Valid options are 'close' or 'latest'.
 
     Returns:
         pd.Series: Series with datetime index and float values representing
@@ -74,6 +76,8 @@ def get_risk_overlay_live(
     """
     url = f"{BASEAPI}/portfolio/risk-overlay-live"
     params = {"portfolio": portfolio, "overlay": overlay}
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)
@@ -131,6 +135,7 @@ def get_risk_regime(
 def get_risk_regime_live(
     overlay: str,
     api_key: str,
+    as_of: str | None = None,
 ) -> pd.Series:
     """
     Retrieve the latest market-wide risk regime value.
@@ -138,6 +143,7 @@ def get_risk_regime_live(
     Args:
         overlay: Risk overlay ID (see [Unravel Catalog](https://unravel.finance/home/api/catalog/risk-overlays))
         api_key: API authentication key
+        as_of: Optional point in time for the data. Valid options are 'close' or 'latest'.
 
     Returns:
         pd.Series: Series with datetime index and float values representing
@@ -148,6 +154,8 @@ def get_risk_regime_live(
     """
     url = f"{BASEAPI}/risk-regime-live"
     params = {"overlay": overlay}
+    if as_of is not None:
+        params["as_of"] = as_of
 
     headers = get_headers(api_key)
     response = requests.get(url, headers=headers, params=params)

--- a/tests/test_live_weights.py
+++ b/tests/test_live_weights.py
@@ -22,3 +22,13 @@ def test_series_dtypes(api_key, test_portfolio):
 
     # Check that all values are float type
     assert pd.api.types.is_float_dtype(result)
+
+
+def test_as_of_close_vs_latest_differ(api_key, test_portfolio):
+    """Test that as_of='close' and as_of='latest' return different results."""
+    result_close = get_live_weights(id=test_portfolio, api_key=api_key, as_of="close")
+    result_latest = get_live_weights(id=test_portfolio, api_key=api_key, as_of="latest")
+
+    assert not result_close.equals(result_latest), (
+        "as_of='close' and as_of='latest' should return different weights"
+    )

--- a/tests/test_portfolio_factors_live.py
+++ b/tests/test_portfolio_factors_live.py
@@ -53,3 +53,30 @@ def test_get_portfolio_factors_live_with_smoothing(
         assert isinstance(result, pd.Series)
         assert len(result) > 0, "Should have some live factor data"
         assert pd.api.types.is_float_dtype(result), "Values should be float type"
+
+
+def test_as_of_close_vs_latest_differ(api_key, test_portfolio, test_portfolio_base):
+    """Test that as_of='close' and as_of='latest' return different results."""
+    tickers = get_tickers(
+        id=test_portfolio_base,
+        api_key=api_key,
+        universe_size=20,
+    )
+
+    if len(tickers) > 0:
+        result_close = get_portfolio_factors_live(
+            id=test_portfolio,
+            tickers=tickers[:3],
+            api_key=api_key,
+            as_of="close",
+        )
+        result_latest = get_portfolio_factors_live(
+            id=test_portfolio,
+            tickers=tickers[:3],
+            api_key=api_key,
+            as_of="latest",
+        )
+
+        assert not result_close.equals(result_latest), (
+            "as_of='close' and as_of='latest' should return different factor values"
+        )

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -55,6 +55,26 @@ def test_get_risk_overlays_live_success(api_key, test_portfolio_base):
     assert pd.api.types.is_float_dtype(result)
 
 
+def test_get_risk_overlay_live_as_of_close_vs_latest_differ(api_key, test_portfolio_base):
+    """Test that as_of='close' and as_of='latest' return different overlay dates."""
+    result_close = get_risk_overlay_live(
+        portfolio=test_portfolio_base,
+        overlay="trend",
+        api_key=api_key,
+        as_of="close",
+    )
+    result_latest = get_risk_overlay_live(
+        portfolio=test_portfolio_base,
+        overlay="trend",
+        api_key=api_key,
+        as_of="latest",
+    )
+
+    assert result_close.index[0] != result_latest.index[0], (
+        "as_of='close' and as_of='latest' should return different risk overlay dates"
+    )
+
+
 def test_get_risk_regime_success(api_key):
     """Test successful retrieval of risk regime data."""
     result = get_risk_regime(
@@ -93,3 +113,21 @@ def test_get_risk_regime_live_success(api_key):
     assert isinstance(result, pd.Series)
     assert len(result) == 1
     assert pd.api.types.is_float_dtype(result)
+
+
+def test_get_risk_regime_live_as_of_close_vs_latest_differ(api_key):
+    """Test that as_of='close' and as_of='latest' return different regime dates."""
+    result_close = get_risk_regime_live(
+        overlay="crypto_trend_consensus",
+        api_key=api_key,
+        as_of="close",
+    )
+    result_latest = get_risk_regime_live(
+        overlay="crypto_trend_consensus",
+        api_key=api_key,
+        as_of="latest",
+    )
+
+    assert result_close.index[0] != result_latest.index[0], (
+        "as_of='close' and as_of='latest' should return different risk regime dates"
+    )


### PR DESCRIPTION
## Summary

Consolidates five commits that were pushed directly to `main` (`d280ebb` → `0327006`) into a single PR so the changes can land via review. These commits have been cherry-picked onto `a29b466` (new SHAs) so the PR is well-formed; once this PR is merged, `main` can be force-reset to drop the original direct-push commits.

Original commits captured here:
- `d280ebb` Add `as_of` parameter to live-weights and live-factors endpoints
- `04f82dc` Add tests asserting `as_of` close and latest return different results
- `dbb7feb` Enable `ubuntu-latest` in tests CI matrix
- `5c74d61` Add `scripts/run_endpoint.py`, `.vscode/launch.json`, risk endpoint tweaks, README updates, risk tests
- `0327006` Expand `.vscode/launch.json` and README

## Cleanup

After this PR is merged, run locally to drop the original commits from `main`:

```
git fetch origin
git checkout main
git reset --hard a29b466
git push origin main --force-with-lease
```

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, force-reset `main` to drop the original direct-push commits

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQmqYTBVVnx8L2To7k6EZH)_