### PR TITLE
feature(CI): Improve bump-version workflow with GitHub App authentication

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,4 +1,4 @@
-name: bump-version 
+name: bump-version
 on:
   workflow_dispatch:
     inputs:
@@ -17,8 +17,16 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.BUMP_APP_ID }}
+          private-key: ${{ secrets.BUMP_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: |


### PR DESCRIPTION
## Summary
Updated the `bump-version` workflow to use GitHub App token authentication for git operations, enabling the workflow to trigger subsequent workflows when pushing version bumps and tags.

## Key Changes
- Added GitHub App token generation step using `actions/create-github-app-token@v3` with configured app credentials
- Updated `actions/checkout` to use the generated GitHub App token instead of the default GITHUB_TOKEN
- Upgraded action versions:
  - `actions/checkout`: v3 → v4
  - `actions/setup-python`: v4 → v5
- Fixed trailing whitespace in workflow name

## Implementation Details
The GitHub App token approach allows the workflow to authenticate with elevated permissions, ensuring that commits and tags pushed by this workflow can trigger other workflows (such as release workflows). This is necessary because the default `GITHUB_TOKEN` cannot trigger subsequent workflow runs for security reasons.

The app credentials (`BUMP_APP_ID` and `BUMP_APP_PRIVATE_KEY`) are stored as repository secrets and used to generate a temporary token for the duration of the workflow execution.

https://claude.ai/code/session_01GJBYXrgf8AxfGHGNe9Mzec